### PR TITLE
fix: PA5's Makefile needs same patch as PA4's

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,8 @@ RUN sed -i 's/-zx/-ozx/g' \
 #   d) be as non-invasive as possible to the existing assignment code
 RUN patch -u /usr/class/assignments/PA2/cool.flex -i /tmp/build/cool.flex.patch \
     && patch -u /usr/class/assignments/PA3/cool.y -i /tmp/build/cool.y.patch \
-    && patch -u /usr/class/assignments/PA4/Makefile -i /tmp/build/Makefile.patch
+    && patch -u /usr/class/assignments/PA4/Makefile -i /tmp/build/Makefile.patch \
+    && patch -u /usr/class/assignments/PA5/Makefile -i /tmp/build/Makefile.patch
 
 # Setup working directory
 RUN mkdir -p /class


### PR DESCRIPTION
In Makefile of PA5, `-lfl` flag causes linker error. Applying the same patch as PA4's solves the problem. Thanks for this great image!